### PR TITLE
Support irm 03wla sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ iRemocon has following commands (for more details, please see [official document
 * ts 現在時刻設定
 * tg 現在時刻取得
 * vr ファームバージョン番号の取得
+* li 照度センサー値の取得
+* hu 湿度センサー値の取得 ※IRM-03WLA用
+* te 温度センサー値の取得 ※IRM-03WLA用
+* se 照度・湿度・温度センサー値の取得 ※IRM-03WLA用
 
 You can call it as an instance method of Iremocon class.
 
@@ -66,4 +70,16 @@ iremocon.tg
 
 iremocon.vr
 #=> send "*vr"
+
+iremocon.li
+#=> send "*li"
+
+iremocon.hu
+#=> send "*hu"
+
+iremocon.te
+#=> send "*te"
+
+iremocon.se
+#=> send "*se"
 ```

--- a/lib/iremocon.rb
+++ b/lib/iremocon.rb
@@ -50,6 +50,22 @@ class Iremocon
     command("vr")
   end
 
+  def li
+    command("li")
+  end
+
+  def hu
+    command("hu")
+  end
+
+  def te
+    command("te")
+  end
+
+  def se
+    command("se")
+  end
+
   private
 
   def connect

--- a/spec/iremocon_spec.rb
+++ b/spec/iremocon_spec.rb
@@ -10,7 +10,7 @@ describe Iremocon do
   end
 
   before do
-    client.stub(:puts) # To silence a command result
+    allow(client).to receive(:puts) # To silence a command result
   end
 
   after do
@@ -21,7 +21,7 @@ describe Iremocon do
   describe "#new" do
     context "when connection succeeded" do
       it "should connect to tcp server by Net::Telnet client" do
-        client.telnet.should be_a(Net::Telnet)
+        expect(client.telnet).to be_kind_of(Net::Telnet)
       end
     end
 
@@ -36,85 +36,85 @@ describe Iremocon do
 
   describe "#au" do
     it "should send *au" do
-      client.telnet.should_receive(:cmd).with("*au")
+      expect(client.telnet).to receive(:cmd).with("*au")
       client.au
     end
   end
 
   describe "#is" do
     it "should send *is;<channel>" do
-      client.telnet.should_receive(:cmd).with("*is;1")
+      expect(client.telnet).to receive(:cmd).with("*is;1")
       client.is(1)
     end
   end
 
   describe "#ic" do
     it "should send *ic;<channel>" do
-      client.telnet.should_receive(:cmd).with("*ic;1")
+      expect(client.telnet).to receive(:cmd).with("*ic;1")
       client.ic(1)
     end
   end
 
   describe "#cc" do
     it "should send *cc" do
-      client.telnet.should_receive(:cmd).with("*cc")
+      expect(client.telnet).to receive(:cmd).with("*cc")
       client.cc
     end
   end
 
   describe "#tm" do
     it "should send *tm;<channel>;<time>;<interval>" do
-      client.telnet.should_receive(:cmd).with("*tm;1;946652400;60")
+      expect(client.telnet).to receive(:cmd).with("*tm;1;946652400;60")
       client.tm(1, 946652400, 60)
     end
 
     it "should convert time to epoch time" do
-      client.telnet.should_receive(:cmd).with("*tm;1;946652400;60")
+      expect(client.telnet).to receive(:cmd).with("*tm;1;946652400;60")
       client.tm(1, Time.local(2000), 60)
     end
 
     it "should complement interval with 0 as default" do
-      client.telnet.should_receive(:cmd).with("*tm;1;946652400;0")
+      expect(client.telnet).to receive(:cmd).with("*tm;1;946652400;0")
       client.tm(1, Time.local(2000))
     end
   end
 
   describe "#tl" do
     it "should send *tl" do
-      client.telnet.should_receive(:cmd).with("*tl")
+      expect(client.telnet).to receive(:cmd).with("*tl")
       client.tl
     end
   end
 
   describe "#td" do
     it "should send *td;<timer_id>" do
-      client.telnet.should_receive(:cmd).with("*td;1")
+      expect(client.telnet).to receive(:cmd).with("*td;1")
       client.td(1)
     end
   end
 
   describe "#ts" do
     it "should send *ts;<time>" do
-      client.telnet.should_receive(:cmd).with("*ts;946652400")
+      expect(client.telnet).to receive(:cmd).with("*ts;946652400")
       client.ts(946652400)
     end
 
     it "should convert time to epoch time" do
-      client.telnet.should_receive(:cmd).with("*ts;946652400")
+      expect(client.telnet).to receive(:cmd).with("*ts;946652400")
       client.ts(Time.local(2000))
     end
   end
 
   describe "#tg" do
     it "should send *tg" do
-      client.telnet.should_receive(:cmd).with("*tg")
+      expect(client.telnet).to receive(:cmd).with("*tg")
       client.tg
     end
   end
 
   describe "#vr" do
     it "should send *vr" do
-      client.telnet.should_receive(:cmd).with("*vr")
+      expect(client.telnet).to receive(:cmd).with("*vr")
       client.vr
     end
   end

--- a/spec/iremocon_spec.rb
+++ b/spec/iremocon_spec.rb
@@ -118,4 +118,32 @@ describe Iremocon do
       client.vr
     end
   end
+
+  describe "#li" do
+    it "should send *li" do
+      expect(client.telnet).to receive(:cmd).with("*li")
+      client.li
+    end
+  end
+
+  describe "#hu" do
+    it "should send *hu" do
+      expect(client.telnet).to receive(:cmd).with("*hu")
+      client.hu
+    end
+  end
+
+  describe "#te" do
+    it "should send *te" do
+      expect(client.telnet).to receive(:cmd).with("*te")
+      client.te
+    end
+  end
+
+  describe "#se" do
+    it "should send *se" do
+      expect(client.telnet).to receive(:cmd).with("*se")
+      client.se
+    end
+  end
 end


### PR DESCRIPTION
rspec result

``` bash
morika-t@moog:~/work/iremocon$ bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Installing diff-lcs 1.2.5
Using iremocon 0.0.1 from source at .
Installing rspec-support 3.1.2
Installing rspec-core 3.1.7
Installing rspec-expectations 3.1.2
Installing rspec-mocks 3.1.3
Installing rspec 3.1.0
Using bundler 1.6.0
Your bundle is complete!
It was installed into ./vendor/bundle
morika-t@moog:~/work/iremocon$ git log --oneline
f137306 Update README new sensor command
656dac1 Add commands for iRemocon WiFi(IRM-03WLA)
ae8e1c7 Fix Deprecation Warning
0771654 Take care of closing client socket in spec
3a2b959 Update README about official document
e55ad14 Silence command result in rspec
dca3d2b Update gemspec
5800dc3 Write README
2bf366f Respond to response at once
0593007 Set 51013 as default port
6b6fb8e Implement all commands on iremocon specification
f687700 Iremocon can connect to tcp server
d62dc03 Change Iremocon from module to class
3e29839 Initial commit
morika-t@moog:~/work/iremocon$  bundle exec rspec spec/iremocon_spec.rb
...................

Finished in 0.01686 seconds (files took 0.08322 seconds to load)
19 examples, 0 failures
```
