### PR TITLE
コマンドを送信した際の結果を返り値として渡すようにした

### DIFF
--- a/lib/iremocon.rb
+++ b/lib/iremocon.rb
@@ -76,11 +76,15 @@ class Iremocon
 
   def command(name, *args)
     str = ["*#{name}", *args].compact.join(";")
-    puts catch(:exit) {
-      @telnet.cmd(str) { |res| throw :exit, res }
+    
+    res = ""
+    catch(:exit) {
+        @telnet.cmd(str) { |r| throw :exit, res = r }
     }
   rescue Timeout::Error
     puts "Timeout - 10sec"
+
+    return (res)
   end
 
   class ConnectionError < StandardError; end


### PR DESCRIPTION
### 変更前
- コマンドを送信した際の結果を標準出力していた
### 変更後
- コマンドを送信した際の結果を返り値に渡すようにした
